### PR TITLE
Add API 1.7 app fetching

### DIFF
--- a/appdb/API/API+Apps.swift
+++ b/appdb/API/API+Apps.swift
@@ -1,0 +1,72 @@
+//
+//  API+Apps.swift
+//  appdb
+//
+//  Created by ChatGPT on 2024.
+//
+
+import Alamofire
+import ObjectMapper
+
+extension API {
+    /// Fetch list of official apps
+    static func getOfficialApps(success: @escaping (_ apps: [OfficialApp]) -> Void,
+                                fail: @escaping (_ error: String) -> Void) {
+        let request = AF.request(endpoint + Actions.getOfficialApps.rawValue, headers: headers)
+        quickCheckForErrors(request) { ok, hasError, _ in
+            if ok {
+                request.responseArray(keyPath: "data") { (response: AFDataResponse<[OfficialApp]>) in
+                    switch response.result {
+                    case .success(let items):
+                        success(items)
+                    case .failure(let error):
+                        fail(error.localizedDescription)
+                    }
+                }
+            } else {
+                fail((hasError ?? "Cannot connect").localized())
+            }
+        }
+    }
+
+    /// Fetch list of apps from repositories
+    static func getRepoApps(success: @escaping (_ apps: [RepoApp]) -> Void,
+                            fail: @escaping (_ error: String) -> Void) {
+        let request = AF.request(endpoint + Actions.getRepoApps.rawValue, headers: headers)
+        quickCheckForErrors(request) { ok, hasError, _ in
+            if ok {
+                request.responseArray(keyPath: "data") { (response: AFDataResponse<[RepoApp]>) in
+                    switch response.result {
+                    case .success(let items):
+                        success(items)
+                    case .failure(let error):
+                        fail(error.localizedDescription)
+                    }
+                }
+            } else {
+                fail((hasError ?? "Cannot connect").localized())
+            }
+        }
+    }
+
+    /// Fetch list of user uploaded apps
+    static func getUserApps(success: @escaping (_ apps: [UserApp]) -> Void,
+                            fail: @escaping (_ error: String) -> Void) {
+        let request = AF.request(endpoint + Actions.getUserApps.rawValue, headers: headers)
+        quickCheckForErrors(request) { ok, hasError, _ in
+            if ok {
+                request.responseArray(keyPath: "data") { (response: AFDataResponse<[UserApp]>) in
+                    switch response.result {
+                    case .success(let items):
+                        success(items)
+                    case .failure(let error):
+                        fail(error.localizedDescription)
+                    }
+                }
+            } else {
+                fail((hasError ?? "Cannot connect").localized())
+            }
+        }
+    }
+}
+

--- a/appdb/API/API.swift
+++ b/appdb/API/API.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 import Localize_Swift
 
 enum API {
-    static let endpoint = "https://api.dbservices.to/v1.6/"
+    static let endpoint = "https://api.dbservices.to/v1.7/"
     static let statusEndpoint = "https://status.dbservices.to/API/v1.0/"
     static let itmsHelperEndpoint = "https://dbservices.to/manifest.php"
 
@@ -147,6 +147,9 @@ enum Actions: String {
     case addDylib = "add_dylib"
     case deleteDylib = "delete_dylib"
     case getEnterpriseCerts = "get_enterprise_certs"
+    case getOfficialApps = "get_official_apps"
+    case getRepoApps = "get_repo_apps"
+    case getUserApps = "get_user_apps"
 }
 
 enum ConfigurationParameters: String {

--- a/appdb/Models/OfficialApp.swift
+++ b/appdb/Models/OfficialApp.swift
@@ -1,0 +1,28 @@
+import ObjectMapper
+
+/// Represents an official appdb application returned by API 1.7
+class OfficialApp: Item {
+    var name: String = ""
+    var bundleId: String = ""
+    var version: String = ""
+    var developer: String = ""
+    var description_: String = ""
+    var downloadURL: String = ""
+    var icon: String = ""
+
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+
+    override func mapping(map: Map) {
+        id          <- map["id"]
+        name        <- map["name"]
+        bundleId    <- map["bundle_id"]
+        version     <- map["version"]
+        developer   <- map["developer"]
+        description_ <- map["description"]
+        downloadURL <- map["download_url"]
+        icon        <- map["icon"]
+    }
+}
+

--- a/appdb/Models/RepoApp.swift
+++ b/appdb/Models/RepoApp.swift
@@ -1,0 +1,28 @@
+import ObjectMapper
+
+/// Represents an application hosted on a repository.
+class RepoApp: Item {
+    var name: String = ""
+    var bundleId: String = ""
+    var version: String = ""
+    var developer: String = ""
+    var description_: String = ""
+    var downloadURL: String = ""
+    var icon: String = ""
+
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+
+    override func mapping(map: Map) {
+        id          <- map["id"]
+        name        <- map["name"]
+        bundleId    <- map["bundle_id"]
+        version     <- map["version"]
+        developer   <- map["developer"]
+        description_ <- map["description"]
+        downloadURL <- map["download_url"]
+        icon        <- map["icon"]
+    }
+}
+

--- a/appdb/Models/UserApp.swift
+++ b/appdb/Models/UserApp.swift
@@ -1,0 +1,28 @@
+import ObjectMapper
+
+/// Represents an application uploaded by a user.
+class UserApp: Item {
+    var name: String = ""
+    var bundleId: String = ""
+    var version: String = ""
+    var developer: String = ""
+    var description_: String = ""
+    var downloadURL: String = ""
+    var icon: String = ""
+
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+
+    override func mapping(map: Map) {
+        id          <- map["id"]
+        name        <- map["name"]
+        bundleId    <- map["bundle_id"]
+        version     <- map["version"]
+        developer   <- map["developer"]
+        description_ <- map["description"]
+        downloadURL <- map["download_url"]
+        icon        <- map["icon"]
+    }
+}
+


### PR DESCRIPTION
## Summary
- switch API base endpoint to v1.7
- add models for official, repo and user apps
- expose API methods to fetch new app types

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1cf7f7f083248baea3697e1e226c