### PR TITLE
Add stubs for new AltStore app endpoints

### DIFF
--- a/appdb/API/API+AltStoreApps.swift
+++ b/appdb/API/API+AltStoreApps.swift
@@ -1,0 +1,54 @@
+//
+//  API+AltStoreApps.swift
+//  appdb
+//
+//  Created by ChatGPT on 2024-07-??.
+//
+
+import Alamofire
+
+extension API {
+
+    static func getOfficialAltStoreApps(success: @escaping (_ items: [OfficialAltStoreApp]) -> Void, fail: @escaping (_ error: String) -> Void) {
+        AF.request(endpoint + Actions.getAltStoreOfficialApps.rawValue,
+                   parameters: ["lang": languageCode],
+                   headers: headers)
+            .responseArray(keyPath: "data") { (response: AFDataResponse<[OfficialAltStoreApp]>) in
+                switch response.result {
+                case .success(let apps):
+                    success(apps)
+                case .failure(let error):
+                    fail(error.localizedDescription)
+                }
+            }
+    }
+
+    static func getAltStoreRepoApps(repoId: String, success: @escaping (_ items: [RepoAltStoreApp]) -> Void, fail: @escaping (_ error: String) -> Void) {
+        AF.request(endpoint + Actions.getAltStoreRepoApps.rawValue,
+                   parameters: ["id": repoId, "lang": languageCode],
+                   headers: headers)
+            .responseArray(keyPath: "data") { (response: AFDataResponse<[RepoAltStoreApp]>) in
+                switch response.result {
+                case .success(let apps):
+                    success(apps)
+                case .failure(let error):
+                    fail(error.localizedDescription)
+                }
+            }
+    }
+
+    static func getUserAltStoreApps(success: @escaping (_ items: [UserAltStoreApp]) -> Void, fail: @escaping (_ error: String) -> Void) {
+        AF.request(endpoint + Actions.getAltStoreUserApps.rawValue,
+                   parameters: ["lang": languageCode],
+                   headers: headersWithCookie)
+            .responseArray(keyPath: "data") { (response: AFDataResponse<[UserAltStoreApp]>) in
+                switch response.result {
+                case .success(let apps):
+                    success(apps)
+                case .failure(let error):
+                    fail(error.localizedDescription)
+                }
+            }
+    }
+}
+

--- a/appdb/API/API.swift
+++ b/appdb/API/API.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 import Localize_Swift
 
 enum API {
-    static let endpoint = "https://api.dbservices.to/v1.6/"
+    static let endpoint = "https://api.dbservices.to/v1.7/"
     static let statusEndpoint = "https://status.dbservices.to/API/v1.0/"
     static let itmsHelperEndpoint = "https://dbservices.to/manifest.php"
 
@@ -140,6 +140,9 @@ enum Actions: String {
     case getAltStoreRepos = "get_altstore_repos"
     case editAltStoreRepo = "edit_altstore_repo"
     case deleteAltStoreRepo = "delete_altstore_repo"
+    case getAltStoreOfficialApps = "get_altstore_official_apps"
+    case getAltStoreRepoApps = "get_altstore_repo_apps"
+    case getAltStoreUserApps = "get_altstore_user_apps"
     case getPlusPurchaseOptions = "get_plus_purchase_options"
     case getSideloadingOptions = "get_sideloading_options"
     case getFeatures = "get_features"

--- a/appdb/Models/AltStoreNewApps.swift
+++ b/appdb/Models/AltStoreNewApps.swift
@@ -1,0 +1,27 @@
+//
+//  AltStoreNewApps.swift
+//  appdb
+//
+//  Created by ChatGPT on 2024-07-??.
+//
+
+import ObjectMapper
+
+class OfficialAltStoreApp: AltStoreApp {
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+}
+
+class RepoAltStoreApp: AltStoreApp {
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+}
+
+class UserAltStoreApp: AltStoreApp {
+    required init?(map: Map) {
+        super.init(map: map)
+    }
+}
+


### PR DESCRIPTION
## Summary
- prepare for API 1.7 by pointing endpoint to the new version
- scaffold models for official, repo and user AltStore apps
- add placeholder API methods to fetch the new app lists

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ce417cc8324a5790efca8eb213f